### PR TITLE
Add new parameters to getTransactionsToApprove

### DIFF
--- a/api.go
+++ b/api.go
@@ -499,14 +499,18 @@ type GetTransactionsToApproveResponse struct {
 }
 
 // GetTransactionsToApprove calls GetTransactionsToApprove API.
-func (api *API) GetTransactionsToApprove(depth int64) (*GetTransactionsToApproveResponse, error) {
+func (api *API) GetTransactionsToApprove(depth, numWalks int64, reference Trytes) (*GetTransactionsToApproveResponse, error) {
 	resp := &GetTransactionsToApproveResponse{}
 	err := api.do(&struct {
-		Command string `json:"command"`
-		Depth   int64  `json:"depth"`
+		Command   string `json:"command"`
+		Depth     int64  `json:"depth,omitempty"`
+		NumWalks  int64  `json:"numWalks,omitempty"`
+		Reference Trytes `json:"reference,omitempty"`
 	}{
 		"getTransactionsToApprove",
 		depth,
+		numWalks,
+		reference,
 	}, resp)
 
 	return resp, err

--- a/api_test.go
+++ b/api_test.go
@@ -211,7 +211,7 @@ func TestAPIGetTransactionsToApprove(t *testing.T) {
 		var server = RandomNode()
 		api := NewAPI(server, nil)
 
-		resp, err = api.GetTransactionsToApprove(Depth)
+		resp, err = api.GetTransactionsToApprove(Depth, NumberOfWalks, "")
 		if err == nil {
 			break
 		}

--- a/transfer.go
+++ b/transfer.go
@@ -30,6 +30,9 @@ import (
 	"time"
 )
 
+// Number of random walks to perform. Currently IRI limits it to 5 to 27
+const NumberOfWalks = 5
+
 // GetUsedAddress generates a new address which is not found in the tangle
 // and returns its new address and used addresses.
 func GetUsedAddress(api *API, seed Trytes, security int) (Address, []Address, error) {
@@ -286,7 +289,7 @@ func signInputs(inputs []AddressInfo, bundle Bundle) error {
 				break
 			}
 		}
-    
+
 		// Get corresponding private key of the address
 		key, err := ai.Key()
 		if err != nil {
@@ -338,7 +341,7 @@ func doPow(tra *GetTransactionsToApproveResponse, depth int64, trytes []Transact
 
 // SendTrytes does attachToTangle and finally, it broadcasts the transactions.
 func SendTrytes(api *API, depth int64, trytes []Transaction, mwm int64, pow PowFunc) error {
-	tra, err := api.GetTransactionsToApprove(depth)
+	tra, err := api.GetTransactionsToApprove(depth, NumberOfWalks, "")
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Add support for selecting a root transaction to start from when selecting tips as well as the number of random walks that should be performed. 