### PR TITLE
Allow building on all archs

### DIFF
--- a/pow_c.go
+++ b/pow_c.go
@@ -1,5 +1,5 @@
 // +build cgo
-// +build linux darwin
+// +build linux darwin windows
 
 /*
 MIT License

--- a/pow_sse.go
+++ b/pow_sse.go
@@ -1,4 +1,4 @@
-// +build linux,amd64
+// +build linux,darwin,windows amd64
 
 /*
 MIT License
@@ -26,8 +26,8 @@ SOFTWARE.
 
 package giota
 
-// #cgo LDFLAGS: -msse2
-// #cgo CFLAGS:  -msse2 -Wall
+// #cgo LDFLAGS:
+// #cgo CFLAGS: -Wall
 /*
 #include <stdio.h>
 #include <string.h>


### PR DESCRIPTION
This removes the `msse2` cflag because it 1) causes build errors on some systems and 2) isn't needed because by default amd64 includes sse2. This also enables PowC on darwin and windows and PowSSE on them as well. In my experience PowSSE works on darwin but PowC is faster. If others can confirm this is the case for them as well then I will disable PowSSE for darwin but Windows has certainly sped up using SSE.