### PR TITLE
expose getvalidhash

### DIFF
--- a/bundle.go
+++ b/bundle.go
@@ -144,6 +144,12 @@ func (bs Bundle) getValidHash() Trytes {
 	}
 }
 
+// GetValidHash exposes getValidHash, as needed when using external 
+// signing implementation
+func (bs Bundle) GetValidHash() Trytes {
+    return bs.getValidHash()
+}
+
 func getTritsToHash(buf Trits, b *Transaction, i, l int) {
 	copy(buf, Trytes(b.Address).Trits())
 	copy(buf[243:], Int2Trits(b.Value, ValueTrinarySize))

--- a/bundle.go
+++ b/bundle.go
@@ -80,7 +80,7 @@ func (bs *Bundle) Add(num int, address Address, value int64, timestamp time.Time
 
 // Finalize filled sigs, bundlehash, and indices elements in bundle.
 func (bs Bundle) Finalize(sig []Trytes) {
-	h := bs.getValidHash()
+	h := bs.GetValidHash()
 
 	for i := range bs {
 		if len(sig) > i && sig[i] != "" {
@@ -107,9 +107,9 @@ func (bs Bundle) Hash() Trytes {
 	return h.Trytes()
 }
 
-// getValidHash calculates hash of Bundle and increases ObsoleteTag value
+// GetValidHash calculates hash of Bundle and increases ObsoleteTag value
 // until normalized hash doesn't have any 13
-func (bs Bundle) getValidHash() Trytes {
+func (bs Bundle) GetValidHash() Trytes {
 	k := NewKerl()
 	hashedLen := BundleTrinaryOffset - AddressTrinaryOffset
 
@@ -142,12 +142,6 @@ func (bs Bundle) getValidHash() Trytes {
 		k.Reset()
 		incTrits(buf[offset : offset+ObsoleteTagTrinarySize])
 	}
-}
-
-// GetValidHash exposes getValidHash, as needed when using external 
-// signing implementation
-func (bs Bundle) GetValidHash() Trytes {
-    return bs.getValidHash()
 }
 
 func getTritsToHash(buf Trits, b *Transaction, i, l int) {


### PR DESCRIPTION
This exposes `Bundle.getValidHash()` as `Bundle.GetValidHash()`, for applications that use an external component for signing the bundle. Maybe not the optimal solution though,