### PR TITLE
Removed unused import 'fmt'

### DIFF
--- a/pow_cARM_ARM64.go
+++ b/pow_cARM_ARM64.go
@@ -291,7 +291,6 @@ import (
 	"errors"
 	"sync"
 	"unsafe"
-  "fmt"
 )
 
 func init() {


### PR DESCRIPTION
Sorry, I broke the lib by removing the debug outputs.
Unfortunately Travis CI is not compiling for ARM64, otherwise I would have recognized that :)
Should be OK now.