### PR TITLE
Added GetPowFunc() and GetPowFuncNames() and changed transactionTrinarySize from private to puplic 

### DIFF
--- a/pow_avx.go
+++ b/pow_avx.go
@@ -334,9 +334,9 @@ var countAVX int64
 func PowAVX(trytes Trytes, mwm int) (Trytes, error) {
 	countAVX = 0
 	c := NewCurl()
-	c.Absorb(trytes[:(transactionTrinarySize-HashSize)/3])
+	c.Absorb(trytes[:(TransactionTrinarySize-HashSize)/3])
 	tr := trytes.Trits()
-	copy(c.state, tr[transactionTrinarySize-HashSize:])
+	copy(c.state, tr[TransactionTrinarySize-HashSize:])
 	var (
 		stop   int64
 		result Trytes

--- a/pow_c.go
+++ b/pow_c.go
@@ -260,9 +260,9 @@ func PowC(trytes Trytes, mwm int) (Trytes, error) {
 	countC = 0
 
 	c := NewCurl()
-	c.Absorb(trytes[:(transactionTrinarySize-HashSize)/3])
+	c.Absorb(trytes[:(TransactionTrinarySize-HashSize)/3])
 	tr := trytes.Trits()
-	copy(c.state, tr[transactionTrinarySize-HashSize:])
+	copy(c.state, tr[TransactionTrinarySize-HashSize:])
 
 	var (
 		result Trytes

--- a/pow_c128.go
+++ b/pow_c128.go
@@ -326,9 +326,9 @@ func PowC128(trytes Trytes, mwm int) (Trytes, error) {
 	C.stopC128 = 0
 	countC128 = 0
 	c := NewCurl()
-	c.Absorb(trytes[:(transactionTrinarySize-HashSize)/3])
+	c.Absorb(trytes[:(TransactionTrinarySize-HashSize)/3])
 	tr := trytes.Trits()
-	copy(c.state, tr[transactionTrinarySize-HashSize:])
+	copy(c.state, tr[TransactionTrinarySize-HashSize:])
 
 	var (
 		result Trytes

--- a/pow_cARM_ARM64.go
+++ b/pow_cARM_ARM64.go
@@ -314,9 +314,9 @@ func PowCARM64(trytes Trytes, mwm int) (Trytes, error) {
 	C.stopCARM64 = 0
 	countCARM64 = 0
 	c := NewCurl()
-	c.Absorb(trytes[:(transactionTrinarySize-HashSize)/3])
+	c.Absorb(trytes[:(TransactionTrinarySize-HashSize)/3])
 	tr := trytes.Trits()
-	copy(c.state, tr[transactionTrinarySize-HashSize:])
+	copy(c.state, tr[TransactionTrinarySize-HashSize:])
 
 	var (
 		result Trytes

--- a/pow_cl.go
+++ b/pow_cl.go
@@ -291,9 +291,9 @@ func PowCL(trytes Trytes, mwm int) (Trytes, error) {
 	stopCL = false
 	countCL = 0
 	c := NewCurl()
-	c.Absorb(trytes[:(transactionTrinarySize-HashSize)/3])
+	c.Absorb(trytes[:(TransactionTrinarySize-HashSize)/3])
 	tr := trytes.Trits()
-	copy(c.state, tr[transactionTrinarySize-HashSize:])
+	copy(c.state, tr[TransactionTrinarySize-HashSize:])
 
 	lmid, hmid := para(c.state)
 	lmid[0] = low0

--- a/pow_go.go
+++ b/pow_go.go
@@ -265,9 +265,9 @@ func PowGo(trytes Trytes, mwm int) (Trytes, error) {
 	stopGO = false
 
 	c := NewCurl()
-	c.Absorb(trytes[:(transactionTrinarySize-HashSize)/3])
+	c.Absorb(trytes[:(TransactionTrinarySize-HashSize)/3])
 	tr := trytes.Trits()
-	copy(c.state, tr[transactionTrinarySize-HashSize:])
+	copy(c.state, tr[TransactionTrinarySize-HashSize:])
 
 	var (
 		result Trytes

--- a/pow_go.go
+++ b/pow_go.go
@@ -26,6 +26,7 @@ package giota
 
 import (
 	"errors"
+	"fmt"
 	"runtime"
 	"sync"
 )
@@ -64,6 +65,28 @@ func init() {
 	if PowProcs != 1 {
 		PowProcs--
 	}
+}
+
+// GetPowFunc returns a specific PoW func
+func GetPowFunc(pow string) (PowFunc, error) {
+	if p, exist := powFuncs[pow]; exist {
+		return p, nil
+	}
+
+	return nil, fmt.Errorf("PowFunc %v does not exist", pow)
+}
+
+// GetPowFuncNames returns an array with the names of the existing PoW methods
+func GetPowFuncNames() (powFuncNames []string) {
+	powFuncNames = make([]string, len(powFuncs))
+
+	i := 0
+	for k := range powFuncs {
+		powFuncNames[i] = k
+		i++
+	}
+
+	return powFuncNames
 }
 
 // GetBestPoW returns most preferable PoW func.

--- a/pow_sse.go
+++ b/pow_sse.go
@@ -294,9 +294,9 @@ func PowSSE(trytes Trytes, mwm int) (Trytes, error) {
 	C.stopSSE = 0
 	countSSE = 0
 	c := NewCurl()
-	c.Absorb(trytes[:(transactionTrinarySize-HashSize)/3])
+	c.Absorb(trytes[:(TransactionTrinarySize-HashSize)/3])
 	tr := trytes.Trits()
-	copy(c.state, tr[transactionTrinarySize-HashSize:])
+	copy(c.state, tr[TransactionTrinarySize-HashSize:])
 
 	var (
 		result Trytes

--- a/transaction.go
+++ b/transaction.go
@@ -91,7 +91,7 @@ const (
 	NonceTrinaryOffset                         = AttachmentTimestampUpperBoundTrinaryOffset + AttachmentTimestampUpperBoundTrinarySize
 	NonceTrinarySize                           = 81
 
-	transactionTrinarySize = SignatureMessageFragmentTrinarySize + AddressTrinarySize +
+	TransactionTrinarySize = SignatureMessageFragmentTrinarySize + AddressTrinarySize +
 		ValueTrinarySize + ObsoleteTagTrinarySize + TimestampTrinarySize +
 		CurrentIndexTrinarySize + LastIndexTrinarySize + BundleTrinarySize +
 		TrunkTransactionTrinarySize + BranchTransactionTrinarySize +
@@ -121,7 +121,7 @@ func checkTx(trytes Trytes) error {
 	switch {
 	case err != nil:
 		return errors.New("invalid transaction " + err.Error())
-	case len(trytes) != transactionTrinarySize/3:
+	case len(trytes) != TransactionTrinarySize/3:
 		return errors.New("invalid trits counts in transaction")
 	case trytes[2279:2295] != "9999999999999999":
 		return errors.New("invalid value in transaction")
@@ -157,7 +157,7 @@ func (t *Transaction) parser(trits Trits) error {
 
 // Trytes converts the transaction to Trytes.
 func (t *Transaction) Trytes() Trytes {
-	tr := make(Trits, transactionTrinarySize)
+	tr := make(Trits, TransactionTrinarySize)
 	copy(tr, t.SignatureMessageFragment.Trits())
 	copy(tr[AddressTrinaryOffset:], Trytes(t.Address).Trits())
 	copy(tr[ValueTrinaryOffset:], Int2Trits(t.Value, ValueTrinarySize))


### PR DESCRIPTION
Hi giota Team!

I needed a possibility to check from outside of the giota lib if a special Pow function exists.
Otherwise my build would fail on an ARM64 device, if I directly access the PoWSSE function in my code, which is needed on INTEL/AMD plattforms.

Another important information in our project was the transactionTrinarySize, which is the only constant that is private, so I changed it to puplic.