### PR TITLE
Ignore c compiler warnings when building pow_c.go

### DIFF
--- a/pow_c.go
+++ b/pow_c.go
@@ -27,7 +27,7 @@ SOFTWARE.
 
 package giota
 
-// #cgo CFLAGS: -Wall
+// #cgo CFLAGS: -Wall -Wno-overflow
 /*
 #include <stdio.h>
 #include <string.h>


### PR DESCRIPTION
A warning is shown for each definition like:

#define HBITS 0xFFFFFFFFFFFFFFFFL

They get annoying pretty quickly in a logic which is not an issue.

Avoiding these on build: 

![stupid_warnings](https://user-images.githubusercontent.com/3150473/43369295-b7cd80a2-936b-11e8-80b9-b596bbd52118.png)

